### PR TITLE
fixed bug in regions initialization

### DIFF
--- a/tools/heap.cuh
+++ b/tools/heap.cuh
@@ -700,7 +700,7 @@ namespace GPUTools
         ptes[i].init();
         page[i].init();
       }
-      for(uint i = linid; i < numregions; i+= numregions)
+      for(uint i = linid; i < numregions; i+= threads)
         regions[i] = 0;
 
       if(linid == 0)


### PR DESCRIPTION
Bug:
- if there were more regions than threads, some regions would not be initialized

This bugfix was backported from https://github.com/ComputationalRadiationPhysics/mallocMC/commit/96fd48e2228dd809c711f0324ac18536adfa5b87
