### PR TITLE
added availableSlotsHost to ScatterAlloc

### DIFF
--- a/tools/heap.cuh
+++ b/tools/heap.cuh
@@ -720,6 +720,106 @@ namespace GPUTools
       
     }
 
+
+    /** counts how many elements of a size fit inside a given page
+     *
+     * Examines a (potentially already used) page to find how many elements
+     * of size chunksize still fit on the page. This includes hierarchically
+     * organized pages and empty pages. The algorithm determines the number
+     * of chunks in the page in a manner similar to the allocation algorithm
+     * of CreationPolicies::Scatter.
+     *
+     * @param page the number of the page to examine. The page needs to be
+     *        formatted with a chunksize and potentially a hierarchy.
+     * @param chunksize the size of element that should be placed inside the
+     *        page. This size must be appropriate to the formatting of the
+     *        page.
+     */
+    __device__ unsigned countFreeChunksInPage(uint32 page, uint32 chunksize){
+      uint32 filledChunks = _ptes[page].count;
+      if(chunksize <= HierarchyThreshold)
+      {
+        uint32 segmentsize = chunksize*32 + sizeof(uint32); //each segment can hold 32 2nd-level chunks
+        uint32 fullsegments = pagesize / segmentsize; //there might be space for more than 32 segments with 32 2nd-level chunks
+        uint32 additional_chunks = max(0,(int)pagesize - (int)fullsegments*segmentsize - (int)sizeof(uint32))/chunksize;
+        uint32 level2Chunks = fullsegments * 32 + additional_chunks;
+
+        //if(filledChunks > 0 || __popc(_ptes[page].bitmask) != 0){
+        //  uint32 freeChunks = level2Chunks-filledChunks;
+        //  uint* onpagemasks = (uint*)(_page[page].data + chunksize*(fullsegments*32 + additional_chunks));
+        //  printf("Page: %u chunksize: %u  segmentsize: %u  additionalchunks: %u  chunksInPage: %u  filledChunks: %u  freeChunks %u  _ptes.bitmask: %X  onPageMasks(%u): %X %X %X %X %X %X %X %X\n",
+        //      page, _ptes[page].chunksize, segmentsize, additional_chunks, level2Chunks, filledChunks, freeChunks, _ptes[page].bitmask, fullsegments+1,
+        //      onpagemasks[0],
+        //      onpagemasks[1],
+        //      onpagemasks[2],
+        //      onpagemasks[3],
+        //      onpagemasks[4],
+        //      onpagemasks[5],
+        //      onpagemasks[6],
+        //      onpagemasks[7]
+        //      );
+        //}
+        return level2Chunks - filledChunks;
+      }else{
+        uint32 chunksinpage = min(pagesize / chunksize, 32); //without hierarchy, there can not be more than 32 chunks
+        return chunksinpage - filledChunks;
+      }
+    }
+
+    /** counts the number of available slots inside the heap
+     *
+     * Searches the heap for all possible locations of an element with size
+     * slotSize. The used traversal algorithms are similar to the allocation
+     * strategy of CreationPolicies::Scatter, to ensure comparable results.
+     * There are 3 different algorithms, based on the size of the requested
+     * slot: 1 slot spans over multiple pages, 1 slot fits in one chunk
+     * within a page, 1 slot fits in a fraction of a chunk.
+     *
+     * @param slotSize the amount of bytes that a single slot accounts for
+     * @param gid the id of the thread. this id does not have to correspond
+     *        with threadId.x, but there must be a continous range of ids
+     *        beginning from 0.
+     * @param stride the stride should be equal to the number of different
+     *        gids (and therefore of value max(gid)-1)
+     */
+    __device__ unsigned getAvailaibleSlotsDeviceFunction(size_t slotSize, int gid, int stride)
+    {
+      unsigned slotcount = 0;
+      if(slotSize < pagesize){ // multiple slots per page
+        for(uint32 currentpage = gid; currentpage < _numpages; currentpage += stride){
+          uint32 maxchunksize = min(pagesize, wastefactor*(uint32)slotSize);
+          uint32 region = currentpage/regionsize;
+          uint32 regionfilllevel = _regions[region];
+
+          uint32 chunksize = _ptes[currentpage].chunksize;
+          if(chunksize >= slotSize && chunksize <= maxchunksize){ //how many chunks left? (each chunk is big enough)
+            slotcount += countFreeChunksInPage(currentpage, chunksize);
+          }else if(chunksize == 0){
+            chunksize  = max((uint32)slotSize, minChunkSize1); //ensure minimum chunk size
+            slotcount += countFreeChunksInPage(currentpage, chunksize); //how many chunks fit in one page?
+          }else{
+            continue; //the chunks on this page are too small for the request :(
+          }
+        }
+      }else{ // 1 slot needs multiple pages
+        if(gid > 0) return 0; //do this serially
+        uint32 pagestoalloc = divup((uint32)slotSize, pagesize);
+        uint32 freecount = 0;
+        for(uint32 currentpage = _numpages; currentpage > 0;){ //this already includes all superblocks
+          --currentpage;
+          if(_ptes[currentpage].chunksize == 0){
+            if(++freecount == pagestoalloc){
+              freecount = 0;
+              ++slotcount;
+            }
+          }else{ // the sequence of free pages was interrupted
+            freecount = 0;
+          }
+        }
+      }
+      return slotcount;
+    }
+
     
     /**
      * alloc allocates the requested number of bytes via the heap
@@ -754,6 +854,14 @@ namespace GPUTools
   __global__ void initHeap(DeviceHeap<pagesize, accessblocks, regionsize, wastefactor, use_coalescing, resetfreedpages>* heap, void* heapmem, size_t memsize)
   {
     heap->init(heapmem, memsize);
+  }
+
+  template<uint pagesize, uint accessblocks, uint regionsize, uint wastefactor,  bool use_coalescing, bool resetfreedpages>
+  __global__ void getAvailableSlotsKernel(DeviceHeap<pagesize, accessblocks, regionsize, wastefactor, use_coalescing, resetfreedpages>* heap, size_t slotSize, unsigned* slots){
+    int gid       = threadIdx.x + blockIdx.x*blockDim.x;
+    int nWorker   = gridDim.x * blockDim.x;
+    unsigned temp = heap->getAvailaibleSlotsDeviceFunction(slotSize, gid, nWorker);
+    if(temp) atomicAdd(slots, temp);
   }
 
 

--- a/tools/heap_impl.cuh
+++ b/tools/heap_impl.cuh
@@ -51,6 +51,32 @@ void* initHeap(size_t memsize = 8*1024U*1024U)
   return pool;
 }
 
+/** Count, how many elements can be allocated at maximum
+ *
+ * Takes an input size and determines, how many elements of this size can
+ * be allocated with the CreationPolicy Scatter. This will return the
+ * maximum number of free slots of the indicated size. It is not
+ * guaranteed where these slots are (regarding fragmentation). Therefore,
+ * the practically usable number of slots might be smaller. This function
+ * is executed in parallel. Speedup can possibly be increased by a higher
+ * amount of parallel workers.
+ *
+ * @param slotSize the size of allocatable elements to count
+ */
+static unsigned getAvailableSlotsHost(size_t const slotSize){
+  heap_t* heap;
+  CUDA_CHECKED_CALL(cudaGetSymbolAddress((void**)&heap,theHeap));
+  unsigned h_slots = 0;
+  unsigned* d_slots;
+  cudaMalloc((void**) &d_slots, sizeof(unsigned));
+  cudaMemcpy(d_slots, &h_slots, sizeof(unsigned), cudaMemcpyHostToDevice);
+
+  GPUTools::getAvailableSlotsKernel<<<64,256>>>(heap,slotSize, d_slots);
+
+  cudaMemcpy(&h_slots, d_slots, sizeof(unsigned), cudaMemcpyDeviceToHost);
+  cudaFree(d_slots);
+  return h_slots;
+}
 
 
 


### PR DESCRIPTION
Backport of the function `getAvailableSlotsHost` from https://github.com/ComputationalRadiationPhysics/mallocMC
- this function can be called after initialization of the heap. It will count the number of free slots of a particular size.
