### PR TITLE
fixed bug with wrong bitmask in PTE

### DIFF
--- a/tools/heap.cuh
+++ b/tools/heap.cuh
@@ -352,9 +352,8 @@ namespace GPUTools
         uint* onpagemasks = (uint*)(_page[page].data + chunksize*(fullsegments*32 + additional_chunks));
         uint old = atomicAnd(onpagemasks + segment, ~(1 << withinsegment));
 
-        uint elementsinsegment = segment < fullsegments ? 32 : additional_chunks;
-        if(__popc(old) == elementsinsegment)
-          atomicAnd((uint*)&_ptes[page].bitmask, ~(1 << segment));
+        // always do this, since it might fail due to a race-condition with addChunkHierarchy
+        atomicAnd((uint*)&_ptes[page].bitmask, ~(1 << segment));
       }
       else
       {


### PR DESCRIPTION
This bugfix is backported from https://github.com/ComputationalRadiationPhysics/mallocMC/commit/48afb4936e6010048cfd782bcc5f526fe985e3a4

idea of how the bug worked (in hierarchical pages):
- currently selected onpagemask is not full.
- thread starts searching for free slot
- new free slots appear where the thread already searched, while the free
  slots in unvisited places disappear
- thread does not find a free slot, sets `_ptes[page].bitmask` at position of
  the onpagemask to 1, indicating that the onpagemask/segment is completely
  filled.
- since `_ptes[page].bitmask` indicates, that the onpagemask/segment is
  completely filled, no other threads will ever enter this segment.
- The bug hits, since the  `_ptes[page].bitmask` on position onpagemask is
  only set to 0 by a thread that had a completely filled onpagemask and removes
  1 element. Since the onpagemask was never completely filled, no thread will
  perform the reset
- memory is lost.
